### PR TITLE
chore: auto-insertion of `///` and concealment of `/**/` comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,6 @@
 {
     "comments": {
-        "lineComment": "//",
-        "blockComment": ["/*", "*/"]
+        "lineComment": "//"
     },
     "wordPattern": "(`[^`]+`)|([a-zA-Z$_][a-zA-Z0-9$_]*)",
     // symbols used as brackets
@@ -23,5 +22,14 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""]
+    ],
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*///.*$",
+            "action": {
+                "indent": "none",
+                "appendText": "/// "
+            }
+        }
     ]
 }


### PR DESCRIPTION
The regex is made in the way that `///` are only auto-inserted if they don't have any non-space characters to the start of the line. That is, they're not placed at the end of the code lines.

As a bonus, I've concealed `/**/` comments. This part is debatable, but generally pushing people towards more `///` seems beneficial, especially if we consider removing the `/**/` comments in some future.

Feel free to disagree :)

Closes #92