### PR TITLE
feat(completion): add empty `receiver() {}` to completion

### DIFF
--- a/server/src/completion/providers/MessageMethodCompletionProvider.ts
+++ b/server/src/completion/providers/MessageMethodCompletionProvider.ts
@@ -32,6 +32,17 @@ export class MessageMethodCompletionProvider implements CompletionProvider {
         })
 
         result.add({
+            label: "receive",
+            labelDetails: {
+                detail: `() {}`,
+            },
+            kind: CompletionItemKind.Keyword,
+            insertText: "receive() {$0}",
+            insertTextFormat: InsertTextFormat.Snippet,
+            weight: CompletionWeight.KEYWORD,
+        })
+
+        result.add({
             label: "bounced",
             labelDetails: {
                 detail: "(msg: <type>) {}",

--- a/server/src/e2e/suite/testcases/completion/constants.test
+++ b/server/src/e2e/suite/testcases/completion/constants.test
@@ -47,6 +47,7 @@ contract Foo {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Trait constant completion
@@ -66,3 +67,4 @@ trait Foo {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}

--- a/server/src/e2e/suite/testcases/completion/contracts.test
+++ b/server/src/e2e/suite/testcases/completion/contracts.test
@@ -13,6 +13,7 @@ contract Foo {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of contract constants

--- a/server/src/e2e/suite/testcases/completion/traits.test
+++ b/server/src/e2e/suite/testcases/completion/traits.test
@@ -19,6 +19,7 @@ trait Child with Parent {
 2  override fun foo(): Int {} of Parent
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of override methods in trait with deep inheritance
@@ -46,6 +47,7 @@ trait Child with Parent {
 2  override fun bar(name: String): Bool {} of Grand
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of override methods in trait with method
@@ -70,6 +72,7 @@ trait Child with Parent {
 2  override fun bar(): Int {} of Parent
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of fields in trait
@@ -94,6 +97,7 @@ trait Child with Parent {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of fields in trait with deep inheritance
@@ -124,6 +128,7 @@ trait Child with Parent {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of fields in trait with field
@@ -151,6 +156,7 @@ trait Child with Parent {
 13 inline fun name() {}
 13 receive(msg: <type>) {}
 13 receive("<message>") {}
+13 receive() {}
 
 ========================================================================
 Completion of methods and fields without self


### PR DESCRIPTION
Fixes #78