### PR TITLE
feat(completion): show only messages in `bounced()` and `external()` receivers

### DIFF
--- a/server/src/completion/CompletionContext.ts
+++ b/server/src/completion/CompletionContext.ts
@@ -129,12 +129,16 @@ export class CompletionContext {
             const grand = parent.parent
             if (grand?.type === "bounced_function") {
                 this.isBouncedMessage = true
+                this.isMessageContext = true
             }
         }
 
         if (parent.type === "parameter") {
             const grand = parent.parent
             if (grand?.type === "receive_function") {
+                this.isMessageContext = true
+            }
+            if (grand?.type === "external_function") {
                 this.isMessageContext = true
             }
         }

--- a/server/src/e2e/suite/testcases/completion/messages.test
+++ b/server/src/e2e/suite/testcases/completion/messages.test
@@ -48,10 +48,21 @@ contract Foo {
 }
 ------------------------------------------------------------------------
 13 bounced<Type>
-13 map<K, V>
-9  Address
-9  Int
-9  String
 21 Bar
-21 Foo
-24 Var
+
+========================================================================
+Completion in external function
+========================================================================
+primitive Int;
+primitive Address;
+primitive String;
+
+struct Foo {}
+message Bar {}
+trait Var {}
+
+contract Foo {
+    external(msg: <caret>) {}
+}
+------------------------------------------------------------------------
+21 Bar


### PR DESCRIPTION
Fixes #123
Fixes #83