### PR TITLE
feat(hover): add documentation for receivers (`receive`, `bounced`, `external`) and `init()` constructor

### DIFF
--- a/server/src/documentation/receivers_documentation.ts
+++ b/server/src/documentation/receivers_documentation.ts
@@ -1,0 +1,76 @@
+import {InitFunction, MessageFunction} from "@server/psi/Decls"
+import {Expression} from "@server/psi/Node"
+import {BouncedTy, MessageTy} from "@server/types/BaseTy"
+
+const CODE_FENCE = "```"
+
+export function generateInitDoc(func: InitFunction): string | null {
+    const name = func.nameLike()
+
+    const doc = `Constructor function \`init()\` runs on deployment of the contract.
+If a contract has any persistent state variables without default values specified, it must initialize them in this function.`
+
+    const link = "https://docs.tact-lang.org/book/contracts/#init-function"
+    const linkPresentation = `\n\nLearn more in documentation: ${link}`
+
+    return defaultResult(name, doc, linkPresentation)
+}
+
+export function generateReceiverDoc(func: MessageFunction): string | null {
+    const name = func.nameLike()
+
+    const kind = func.kindIdentifier()?.text
+    if (!kind) return null
+
+    const link =
+        kind === "receive"
+            ? "https://docs.tact-lang.org/book/receive/"
+            : kind === "bounced"
+              ? "https://docs.tact-lang.org/book/bounced/"
+              : "https://docs.tact-lang.org/book/external/"
+
+    const linkPresentation = `\n\nLearn more in documentation: ${link}`
+
+    const param = func.parameter()
+    if (!param) {
+        const doc = "Called when an empty message is sent to the contract"
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    if (param.type === "string") {
+        const doc =
+            'Called when a text message with a specific comment is sent to the contract (maximum "message" length is 123 bytes)'
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    const typeNode = param.childForFieldName("type")
+    if (!typeNode) return null
+    const type = new Expression(typeNode, func.file).type()
+    if (!type) return null
+
+    if (type.name() === "String") {
+        const doc = "Called when an arbitrary text message is sent to the contract"
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    if (type instanceof MessageTy) {
+        const doc = `Called when a binary message of type \`${type.name()}\` is sent to the contract`
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    if (type instanceof BouncedTy) {
+        const doc = `Called when a binary message of type \`${type.innerTy.name()}\` is sent to the contract`
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    if (type.name() === "Slice") {
+        const doc = "Called when binary message of unknown type is sent to the contract"
+        return defaultResult(name, doc, linkPresentation)
+    }
+
+    return defaultResult(name, "", linkPresentation)
+}
+
+function defaultResult(name: string, doc: string, linkPresentation: string) {
+    return `${CODE_FENCE}tact\n${name} {}\n${CODE_FENCE}` + "\n" + doc + linkPresentation
+}

--- a/server/src/documentation/receivers_documentation.ts
+++ b/server/src/documentation/receivers_documentation.ts
@@ -11,9 +11,7 @@ export function generateInitDoc(func: InitFunction): string | null {
 If a contract has any persistent state variables without default values specified, it must initialize them in this function.`
 
     const link = "https://docs.tact-lang.org/book/contracts/#init-function"
-    const linkPresentation = `\n\nLearn more in documentation: ${link}`
-
-    return defaultResult(name, doc, linkPresentation)
+    return defaultResult(name, doc, link)
 }
 
 export function generateReceiverDoc(func: MessageFunction): string | null {
@@ -29,18 +27,16 @@ export function generateReceiverDoc(func: MessageFunction): string | null {
               ? "https://docs.tact-lang.org/book/bounced/"
               : "https://docs.tact-lang.org/book/external/"
 
-    const linkPresentation = `\n\nLearn more in documentation: ${link}`
-
     const param = func.parameter()
     if (!param) {
         const doc = "Called when an empty message is sent to the contract"
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
     if (param.type === "string") {
         const doc =
             'Called when a text message with a specific comment is sent to the contract (maximum "message" length is 123 bytes)'
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
     const typeNode = param.childForFieldName("type")
@@ -50,27 +46,33 @@ export function generateReceiverDoc(func: MessageFunction): string | null {
 
     if (type.name() === "String") {
         const doc = "Called when an arbitrary text message is sent to the contract"
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
     if (type instanceof MessageTy) {
         const doc = `Called when a binary message of type \`${type.name()}\` is sent to the contract`
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
     if (type instanceof BouncedTy) {
         const doc = `Called when a binary message of type \`${type.innerTy.name()}\` is sent to the contract`
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
     if (type.name() === "Slice") {
         const doc = "Called when binary message of unknown type is sent to the contract"
-        return defaultResult(name, doc, linkPresentation)
+        return defaultResult(name, doc, link)
     }
 
-    return defaultResult(name, "", linkPresentation)
+    return defaultResult(name, "", link)
 }
 
-function defaultResult(name: string, doc: string, linkPresentation: string) {
-    return `${CODE_FENCE}tact\n${name} {}\n${CODE_FENCE}` + "\n" + doc + linkPresentation
+function defaultResult(name: string, doc: string, link: string) {
+    return (
+        `${CODE_FENCE}tact\n${name} {}\n${CODE_FENCE}` +
+        "\n" +
+        doc +
+        "\n\nLearn more in documentation: " +
+        link
+    )
 }

--- a/server/src/documentation/receivers_documentation.ts
+++ b/server/src/documentation/receivers_documentation.ts
@@ -27,12 +27,16 @@ export function generateReceiverDoc(func: MessageFunction): string | null {
               ? "https://docs.tact-lang.org/book/bounced/"
               : "https://docs.tact-lang.org/book/external/"
 
+    // receive() {}
+    //        ^^
     const param = func.parameter()
     if (!param) {
         const doc = "Called when an empty message is sent to the contract"
         return defaultResult(name, doc, link)
     }
 
+    // receive("message") {}
+    //         ^^^^^^^^^
     if (param.type === "string") {
         const doc =
             'Called when a text message with a specific comment is sent to the contract (maximum "message" length is 123 bytes)'
@@ -44,21 +48,29 @@ export function generateReceiverDoc(func: MessageFunction): string | null {
     const type = new Expression(typeNode, func.file).type()
     if (!type) return null
 
+    // receive(str: String) {}
+    //              ^^^^^^
     if (type.name() === "String") {
         const doc = "Called when an arbitrary text message is sent to the contract"
         return defaultResult(name, doc, link)
     }
 
+    // receive(msg: ChangeOwner) {}
+    //              ^^^^^^^^^^^
     if (type instanceof MessageTy) {
         const doc = `Called when a binary message of type \`${type.name()}\` is sent to the contract`
         return defaultResult(name, doc, link)
     }
 
+    // bounced(msg: bounced<ChangeOwner>) {}
+    //              ^^^^^^^^^^^^^^^^^^^^
     if (type instanceof BouncedTy) {
         const doc = `Called when a binary message of type \`${type.innerTy.name()}\` is sent to the contract`
         return defaultResult(name, doc, link)
     }
 
+    // external(msg: Slice) {}
+    //               ^^^^^
     if (type.name() === "Slice") {
         const doc = "Called when binary message of unknown type is sent to the contract"
         return defaultResult(name, doc, link)

--- a/server/src/psi/Decls.ts
+++ b/server/src/psi/Decls.ts
@@ -178,10 +178,14 @@ export class InitFunction extends Node {
 export class MessageFunction extends Node {
     public nameLike(): string {
         const parametersNode = this.node.childForFieldName("parameter")
-        if (!parametersNode) return "unknown()"
         const kindIdent = this.kindIdentifier()
         if (!kindIdent) return "unknown()"
+        if (!parametersNode) return `${kindIdent.text}()`
         return `${kindIdent.text}(${parametersNode.text})`
+    }
+
+    public parameter(): SyntaxNode | null {
+        return this.node.childForFieldName("parameter")
     }
 
     public kindIdentifier(): SyntaxNode | null {


### PR DESCRIPTION
Fixes #87
Fixes #69
Towards #44