### PR TITLE
feat(vscode): add Tact code highlighting inside Markdown code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
                 "configuration": "./language-configuration.json"
             },
             {
+                "id": "tact-markdown-injection"
+            },
+            {
                 "id": "fift",
                 "aliases": [
                     "Fift"
@@ -84,6 +87,17 @@
                 "language": "fift",
                 "scopeName": "source.fift",
                 "path": "./syntaxes/fift.tmLanguage.json"
+            },
+            {
+                "language": "tact-markdown-injection",
+                "scopeName": "markdown.tact.codeblock",
+                "path": "./syntaxes/tact-markdown-injection.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.tact": "tact"
+                }
             }
         ],
         "snippets": [],

--- a/syntaxes/tact-markdown-injection.json
+++ b/syntaxes/tact-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#tact-code-block"
+        }
+    ],
+    "repository": {
+        "tact-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(tact)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.tact",
+                    "patterns": [
+                        {
+                            "include": "source.tact"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.tact.codeblock"
+}


### PR DESCRIPTION
Fixes #204