### PR TITLE
feat(documentation): show members of trait and contract in hover documentation

### DIFF
--- a/server/src/e2e/suite/testcases/documentation/basic.test
+++ b/server/src/e2e/suite/testcases/documentation/basic.test
@@ -134,7 +134,7 @@ contract <caret>Foo {
 }
 ------------------------------------------------------------------------
 ```tact
-contract Foo
+contract Foo {}
 ```
 And this is documentation comment
 
@@ -148,7 +148,7 @@ contract <caret>Foo {
 }
 ------------------------------------------------------------------------
 ```tact
-contract Foo
+contract Foo {}
 ```
 Some comment. And other!
 

--- a/server/src/e2e/suite/testcases/documentation/contracts.test
+++ b/server/src/e2e/suite/testcases/documentation/contracts.test
@@ -1,20 +1,68 @@
 ========================================================================
+Empty contract documentation
+========================================================================
+primitive String;
+primitive Int;
+
+/// Some cool contract
+contract <caret>Foo {}
+------------------------------------------------------------------------
+```tact
+contract Foo {}
+```
+Some cool contract
+
+========================================================================
 Contract documentation
 ========================================================================
+primitive String;
+primitive Int;
+
+message Some {}
+
 /// Some cool contract
 contract <caret>Foo {
     name: String;
     value: Int;
+
+    init(name: String, value: Int) {
+        self.name = name;
+        self.value = value;
+    }
+
+    receive("hello") {}
+    receive(msg: Some) {}
+    external(msg: Slice) {}
+    bounced(msg: bounced<Some>) {}
+
+    get fun counter(): Int {
+        return self.value;
+    }
 }
 ------------------------------------------------------------------------
 ```tact
-contract Foo
+contract Foo {
+    name: String;
+    value: Int;
+
+    init(name: String, value: Int);
+
+    receive("hello");
+    receive(msg: Some);
+    external(msg: Slice);
+    bounced(msg: bounced<Some>);
+
+    get fun counter(): Int;
+}
 ```
 Some cool contract
 
 ========================================================================
 Contract with inheritance documentation
 ========================================================================
+primitive String;
+primitive Int;
+
 trait Other {}
 
 /// Some cool contract
@@ -24,7 +72,10 @@ contract <caret>Foo with Other {
 }
 ------------------------------------------------------------------------
 ```tact
-contract Foo with Other
+contract Foo with Other {
+    name: String;
+    value: Int;
+}
 ```
 Some cool contract
 

--- a/server/src/e2e/suite/testcases/documentation/traits.test
+++ b/server/src/e2e/suite/testcases/documentation/traits.test
@@ -1,6 +1,9 @@
 ========================================================================
 Trait documentation
 ========================================================================
+primitive String;
+primitive Int;
+
 /// Some cool trait
 trait <caret>Foo {
     name: String;
@@ -8,13 +11,19 @@ trait <caret>Foo {
 }
 ------------------------------------------------------------------------
 ```tact
-trait Foo
+trait Foo {
+    name: String;
+    value: Int;
+}
 ```
 Some cool trait
 
 ========================================================================
 Trait with inheritance documentation
 ========================================================================
+primitive String;
+primitive Int;
+
 trait Other {}
 
 /// Some cool trait
@@ -24,7 +33,10 @@ trait <caret>Foo with Other {
 }
 ------------------------------------------------------------------------
 ```tact
-trait Foo with Other
+trait Foo with Other {
+    name: String;
+    value: Int;
+}
 ```
 Some cool trait
 
@@ -41,3 +53,62 @@ trait Foo {
 trait Foo
 field: Int
 ```
+
+========================================================================
+Trait with method documentation
+========================================================================
+/// Some cool trait
+trait <caret>Foo {
+    fun foo() {}
+}
+------------------------------------------------------------------------
+```tact
+trait Foo {
+    fun foo();
+}
+```
+Some cool trait
+
+========================================================================
+Trait with constant documentation
+========================================================================
+primitive Int;
+
+/// Some cool trait
+trait <caret>Foo {
+    const FOO: Int = 100;
+}
+------------------------------------------------------------------------
+```tact
+trait Foo {
+    const FOO: Int = 100;
+}
+```
+Some cool trait
+
+========================================================================
+Trait with all members documentation
+========================================================================
+primitive Int;
+
+/// Some cool trait
+trait <caret>Foo {
+    const FOO: Int = 100;
+
+    foo: Int;
+
+    abstract fun bar();
+    fun foo() {}
+}
+------------------------------------------------------------------------
+```tact
+trait Foo {
+    const FOO: Int = 100;
+
+    foo: Int;
+
+    abstract fun bar();
+    fun foo();
+}
+```
+Some cool trait


### PR DESCRIPTION

<img width="561" alt="Screenshot 2025-02-18 at 02 37 14" src="https://github.com/user-attachments/assets/a29527e1-871b-4953-af67-e989e0b41e19" />

<img width="1041" alt="Screenshot 2025-02-18 at 02 37 02" src="https://github.com/user-attachments/assets/6df41aac-7f4f-44fe-9712-da59a2fc76e9" />


Fixes #64