### PR TITLE
feat(completion): show `self` type fields/methods in completion list

### DIFF
--- a/server/src/e2e/suite/testcases/completion/methods.test
+++ b/server/src/e2e/suite/testcases/completion/methods.test
@@ -19,3 +19,50 @@ fun test() {
 14 let  Create variable
 14 not  Negate expression
 14 repeat  Create repeat loop
+
+========================================================================
+Completion of struct field of self type
+========================================================================
+primitive Int;
+
+struct Data {
+    active: Bool;
+}
+
+extends fun some(self: Data) {
+    return <caret>
+}
+------------------------------------------------------------------------
+5  self   Data
+9  self.active:    of Data
+13 false
+13 initOf Contract(params)   StateInit
+13 null
+13 true
+2  some(self: Data)
+21 Data{}
+
+========================================================================
+Completion of struct method of self type
+========================================================================
+primitive Int;
+
+struct Data {
+    active: Bool;
+}
+
+extends fun other(self: Data) {}
+
+extends fun some(self: Data) {
+    return <caret>
+}
+------------------------------------------------------------------------
+5  self   Data
+9  self.active:    of Data
+13 false
+13 initOf Contract(params)   StateInit
+13 null
+13 true
+2  other(self: Data)
+2  some(self: Data)
+21 Data{}

--- a/server/src/e2e/suite/testcases/completion/variables.test
+++ b/server/src/e2e/suite/testcases/completion/variables.test
@@ -82,6 +82,7 @@ extends fun move(self: Point, x: Int, y: Int) {
 13 null
 13 return;
 13 true
+2  move(self: Point, x: Int, y: Int)
 21 Point{}
 14 do
 14 foreach
@@ -114,6 +115,7 @@ extends fun scale(self: Point, factor: Int) {
 13 null
 13 return;
 13 true
+2  scale(self: Point, factor: Int)
 21 Point{}
 14 do
 14 foreach

--- a/server/src/psi/Decls.ts
+++ b/server/src/psi/Decls.ts
@@ -291,6 +291,14 @@ export class Fun extends NamedNode {
         return first.name() === "self"
     }
 
+    public selfParam(): NamedNode | null {
+        const params = this.parameters()
+        if (params.length === 0) return null
+        const first = params[0]
+        if (first.name() !== "self") return null
+        return first
+    }
+
     public signaturePresentation(): string {
         const parametersNode = this.node.childForFieldName("parameters")
         if (!parametersNode) return ""


### PR DESCRIPTION
With auto-insertion of `self.` prefix on select

https://github.com/user-attachments/assets/15a3ac5d-c665-45cc-9593-5e4c938e334c

Fixes #70