### PR TITLE
feat(inlay-hints): improve type hints

### DIFF
--- a/server/src/asm/gas.ts
+++ b/server/src/asm/gas.ts
@@ -1,5 +1,6 @@
 import {AsmInstr} from "@server/psi/Node"
 import {getStackPresentation} from "@server/completion/data/types"
+import type {File} from "@server/psi/File"
 
 export interface GasConsumption {
     value: number
@@ -41,6 +42,21 @@ export function computeGasConsumption(instructions: AsmInstr[]): GasConsumption 
         exact,
         singleInstr: singleInstructionBody,
     }
+}
+
+export function calculatePushcontGas(instr: AsmInstr, file: File): GasConsumption | null {
+    const args = instr.arguments()
+    if (args.length === 0) return null
+
+    const arg = args[0]
+    if (arg.type !== "asm_sequence") return null
+
+    const instructions = arg.children
+        .filter(it => it?.type === "asm_expression")
+        .filter(it => it !== null)
+        .map(it => new AsmInstr(it, file))
+
+    return computeGasConsumption(instructions)
 }
 
 export function instructionPresentation(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -832,7 +832,8 @@ connection.onInitialize(async (initParams: lsp.InitializeParams): Promise<lsp.In
         },
     )
 
-    connection.languages.inlayHint.on(
+    connection.onRequest(
+        lsp.InlayHintRequest.type,
         async (params: lsp.InlayHintParams): Promise<lsp.InlayHint[] | null> => {
             const uri = params.textDocument.uri
             if (uri.endsWith(".fif")) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
         "sourceMap": true,
         "strict": true,
         "allowUnreachableCode": true,
-        "exactOptionalPropertyTypes": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitOverride": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
- Add tooltip for `as int257` hint for beginners
- Resolve parts of type hints
- Resolve parameter hints
- Insert type hint on double-click

Fixes #285
Fixes #284
Fixes #283
Fixes #282