### PR TITLE
feat(inlay-hints): don't show an obvious type hint for variable initialized with `Foo.fromCell()`

### DIFF
--- a/server/src/e2e/suite/testcases/inlayHints/variables.test
+++ b/server/src/e2e/suite/testcases/inlayHints/variables.test
@@ -50,3 +50,22 @@ struct Foo { value: Int/*  as int257 */ }
 fun foo() {
     let a = Foo { value: 10 };
 }
+
+========================================================================
+Local variable initialized with fromCell call
+========================================================================
+primitive Int;
+
+struct Foo { value: Int }
+
+fun foo() {
+    let a = Foo.fromCell(emptyCell());
+}
+------------------------------------------------------------------------
+primitive Int;
+
+struct Foo { value: Int/*  as int257 */ }
+
+fun foo() {
+    let a = Foo.fromCell(emptyCell());
+}

--- a/server/src/inlays/collect.ts
+++ b/server/src/inlays/collect.ts
@@ -101,7 +101,7 @@ function processToCellCall(call: CallLike, result: InlayHint[], showToCellSize: 
     })
 }
 
-function isObviousType(expr: SyntaxNode): boolean {
+function hasObviousType(expr: SyntaxNode): boolean {
     // don't show a hint for:
     // let params = SomeParams{}
     if (expr.type === "instance_expression") return true
@@ -156,7 +156,7 @@ export function collect(
             const expr = decl.value()
             if (!expr) return true
 
-            if (isObviousType(expr.node)) return true
+            if (hasObviousType(expr.node)) return true
 
             const name = decl.nameIdentifier()
             if (!name) return true

--- a/server/src/inlays/collect.ts
+++ b/server/src/inlays/collect.ts
@@ -101,6 +101,23 @@ function processToCellCall(call: CallLike, result: InlayHint[], showToCellSize: 
     })
 }
 
+function isObviousType(expr: SyntaxNode): boolean {
+    // don't show a hint for:
+    // let params = SomeParams{}
+    if (expr.type === "instance_expression") return true
+
+    // don't show a hint for:
+    // let foo = Foo.fromCell(cell)
+    if (expr.type === "method_call_expression") {
+        const name = expr.childForFieldName("name")
+        if (name?.text === "fromCell") {
+            return true
+        }
+    }
+
+    return false
+}
+
 export function collect(
     file: File,
     hints: {
@@ -139,9 +156,7 @@ export function collect(
             const expr = decl.value()
             if (!expr) return true
 
-            // don't show hint for:
-            // let params = SomeParams{}
-            if (expr.node.type === "instance_expression") return true
+            if (isObviousType(expr.node)) return true
 
             const name = decl.nameIdentifier()
             if (!name) return true


### PR DESCRIPTION
Fixes #340