### PR TITLE
chore(documentation): override completions in Sublime Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,20 @@ yarn install
 yarn build
 ```
 
-For VS Code extension, additionally run:
+To obtain the `.vsix` package with the VS Code extension, additionally run:
 
 ```shell
 yarn package
+```
+
+And then run either of those to install the extension from the `.vsix` package:
+
+```shell
+# VSCode
+code --install-extension vscode-tact-*.vsix
+
+# VSCodium
+codium --install-extension vscode-tact-*.vsix
 ```
 
 ## Editor Setup
@@ -99,7 +109,8 @@ yarn package
                 "command": ["node", "path/to/language-server/dist/server.js", "--stdio"],
                 "selector": "source.tact"
             }
-        }
+        },
+        "inhibit_snippet_completions": true
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ yarn package
 And then run either of those to install the extension from the `.vsix` package:
 
 ```shell
-# VSCode
-code --install-extension vscode-tact-*.vsix
+# VSCode, replace VERSION with actual version from package.json
+code --install-extension vscode-tact-VERSION.vsix
 
-# VSCodium
-codium --install-extension vscode-tact-*.vsix
+# VSCodium, replace VERSION with actual version from package.json
+codium --install-extension vscode-tact-VERSION.vsix
 ```
 
 ## Editor Setup


### PR DESCRIPTION
And also enhance VSIX-related descriptions a little.

Fix #352 (took some time to test and it indeed works and replaces the default `.sublime-completions` with ones from the LS)