### PR TITLE
feat(inlay-hints): don't show parameter hints for call argument with matching name

### DIFF
--- a/docs/manual/features/inlay-hints.md
+++ b/docs/manual/features/inlay-hints.md
@@ -30,6 +30,8 @@ Parameter hints are skipped when:
 
 - Parameter name matches argument (`takeFoo(foo)`)
 - Argument is a property access matching parameter (`takeFoo(val.foo)`)
+- Argument is a function call with name matching parameter (`takeFoo(foo())`)
+- Argument is a method call with name matching parameter (`takeFoo(val.foo())`)
 - Parameter is a parameter of a well-known unary function like `ton()`
 - Parameter name is a single letter
 

--- a/server/src/e2e/suite/testcases/inlayHints/parameters.test
+++ b/server/src/e2e/suite/testcases/inlayHints/parameters.test
@@ -16,3 +16,87 @@ fun foo(a: int, b: Int) {}
 fun test() {
     foo(1, 2);
 }
+
+========================================================================
+Static call argument with same name
+========================================================================
+primitive Int;
+
+fun sender(): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(sender());
+}
+------------------------------------------------------------------------
+primitive Int;
+
+fun sender(): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(sender());
+}
+
+========================================================================
+Static call argument with almost same name
+========================================================================
+primitive Int;
+
+fun someSender(): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(someSender());
+}
+------------------------------------------------------------------------
+primitive Int;
+
+fun someSender(): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(/* sender: */someSender());
+}
+
+========================================================================
+Method call argument with same name
+========================================================================
+primitive Int;
+
+fun sender(self: Int): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(10.sender());
+}
+------------------------------------------------------------------------
+primitive Int;
+
+fun sender(self: Int): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(10.sender());
+}
+
+========================================================================
+Method call argument with almost same name
+========================================================================
+primitive Int;
+
+fun someSender(self: Int): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(10.someSender());
+}
+------------------------------------------------------------------------
+primitive Int;
+
+fun someSender(self: Int): Int { return 0; }
+fun foo(sender: Int) {}
+
+fun test() {
+    foo(/* sender: */10.someSender());
+}

--- a/server/src/inlays/collect.ts
+++ b/server/src/inlays/collect.ts
@@ -47,13 +47,32 @@ function processParameterHints(
         }
 
         if (arg.text === paramName || arg.text.endsWith(`.${paramName}`)) {
-            // no need to add hint for `takeFoo(foo)` or `takeFoo(val.foo)`
+            // no need to add a hint for `takeFoo(foo)` or `takeFoo(val.foo)`
             continue
         }
 
-        if (arg.children[0]?.type === "instance_expression") {
-            // no need to add hint for `takeFoo(Foo{})`
+        const argExpr = arg.children[0]
+        if (!argExpr) continue
+
+        if (argExpr.type === "instance_expression") {
+            // no need to add a hint for `takeFoo(Foo{})`
             continue
+        }
+
+        if (argExpr.type === "static_call_expression") {
+            const name = argExpr.childForFieldName("name")
+            if (paramName === name?.text) {
+                // no need to add a hint for `takeSender(sender())`
+                continue
+            }
+        }
+
+        if (argExpr.type === "method_call_expression") {
+            const name = argExpr.childForFieldName("name")
+            if (paramName === name?.text) {
+                // no need to add a hint for `takeSender(foo.sender())`
+                continue
+            }
         }
 
         result.push({


### PR DESCRIPTION
Fixes #245