### PR TITLE
fix(inlay-hints): don't show size hint for `toCellI()` in method chain

### DIFF
--- a/server/src/e2e/suite/testcases/inlayHints/toCell.test
+++ b/server/src/e2e/suite/testcases/inlayHints/toCell.test
@@ -34,3 +34,77 @@ fun foo() {
         from: address(""),
     }.toCell()/*  Size: 367 bits plus up to 120 bits */
 }
+
+========================================================================
+toCell call in method chain
+========================================================================
+primitive Int;
+primitive Address;
+
+message(0x7362d09c) TokenNotification {
+    query_id: Int as uint64;
+    amount: Int as coins;
+    from: Address;
+}
+
+fun foo() {
+    const bits = TokenNotification{
+        query_id: 10,
+        amount: 20,
+        from: address(""),
+    }.toCell().bits()
+}
+------------------------------------------------------------------------
+primitive Int;
+primitive Address;
+
+message(0x7362d09c) TokenNotification {
+    query_id: Int as uint64;
+    amount: Int as coins;
+    from: Address;
+}
+
+fun foo() {
+    const bits = TokenNotification{
+        query_id: 10,
+        amount: 20,
+        from: address(""),
+    }.toCell().bits()
+}
+
+========================================================================
+toCell call with field access
+========================================================================
+primitive Int;
+primitive Address;
+
+message(0x7362d09c) TokenNotification {
+    query_id: Int as uint64;
+    amount: Int as coins;
+    from: Address;
+}
+
+fun foo() {
+    const bits = TokenNotification{
+        query_id: 10,
+        amount: 20,
+        from: address(""),
+    }.toCell().bits
+}
+------------------------------------------------------------------------
+primitive Int;
+primitive Address;
+
+message(0x7362d09c) TokenNotification {
+    query_id: Int as uint64;
+    amount: Int as coins;
+    from: Address;
+}
+
+fun foo() {
+    const bits = TokenNotification{
+        query_id: 10,
+        amount: 20,
+        from: address(""),
+    }.toCell().bits
+}

--- a/server/src/inlays/collect.ts
+++ b/server/src/inlays/collect.ts
@@ -98,6 +98,15 @@ function processToCellCall(call: CallLike, result: InlayHint[], showToCellSize: 
     if (!showToCellSize) return
     if (call.node.type !== "method_call_expression" || call.name() !== "toCell") return
 
+    const parent = call.node.parent
+
+    // if:
+    // Foo{}.asCell().bits()
+    // Foo{}.asCell().bits
+    if (parent?.type === "method_call_expression" || parent?.type === "field_access_expression") {
+        return
+    }
+
     const qualifier = call.node.childForFieldName("object")
     if (!qualifier) {
         return


### PR DESCRIPTION
Fixes #430