### PR TITLE
fix(document-symbols): document symbols now return whole range of declaration, not only name

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1652,7 +1652,7 @@ connection.onInitialize(async (initParams: lsp.InitializeParams): Promise<lsp.In
                 return {
                     name: element.name(),
                     kind: kind,
-                    range: asNullableLspRange(element.node),
+                    range: asLspRange(element.node),
                     detail: detail,
                     selectionRange: asNullableLspRange(element.nameIdentifier()),
                     children: children,


### PR DESCRIPTION
Fixes #453