### PR TITLE
fix(find-usages): correctly determine whether some reference is a reference to target declaration and not another

### DIFF
--- a/server/src/psi/Referent.ts
+++ b/server/src/psi/Referent.ts
@@ -218,6 +218,7 @@ export class Referent {
 
             if (
                 res.node.type === resolved.node.type &&
+                res.file.uri === resolved.file.uri &&
                 res.node.startPosition.row === resolved.node.startPosition.row &&
                 (identifier.text === resolved.name() || identifier.text === "self")
             ) {


### PR DESCRIPTION
Fixes #546