### PR TITLE
fix(inlay-hints): do not show evaluation result for incorrect `ascii()` usage

### DIFF
--- a/server/src/compiler/utils.ts
+++ b/server/src/compiler/utils.ts
@@ -37,16 +37,16 @@ export function evalCrc32Builtin(rawStr: string): bigint {
     return crc32BigInt(rawStr)
 }
 
-export function evalAsciiBuiltin(rawStr: string): bigint {
+export function evalAsciiBuiltin(rawStr: string): undefined | bigint {
     const str = processEscapes(rawStr)
 
     const encoded = new TextEncoder().encode(str)
     if (encoded.length > 32) {
-        return -1n
+        return undefined
     }
 
     if (encoded.length === 0) {
-        return 0n
+        return undefined
     }
 
     let hexString = ""

--- a/server/src/e2e/suite/testcases/inlayHints/ascii.test
+++ b/server/src/e2e/suite/testcases/inlayHints/ascii.test
@@ -90,3 +90,37 @@ fun ascii(str: String): Int;
 
 const FOO: Int = ascii(/* str: */"\u{1F602}")/*  Evaluates to: 0xf09f9882 */;
 const FOO: Int = ascii(/* str: */"😂")/*  Evaluates to: 0xf09f9882 */; // same value
+
+========================================================================
+Ascii with empty string
+========================================================================
+primitive Int;
+primitive String;
+
+fun ascii(str: String): Int;
+
+const FOO: Int = ascii(""); // evaluation error
+------------------------------------------------------------------------
+primitive Int;
+primitive String;
+
+fun ascii(str: String): Int;
+
+const FOO: Int = ascii(""); // evaluation error
+
+========================================================================
+Ascii with more than 32 bytes
+========================================================================
+primitive Int;
+primitive String;
+
+fun ascii(str: String): Int;
+
+const FOO: Int = ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡"); // evaluation error
+------------------------------------------------------------------------
+primitive Int;
+primitive String;
+
+fun ascii(str: String): Int;
+
+const FOO: Int = ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡"); // evaluation error

--- a/server/src/inlays/collect.ts
+++ b/server/src/inlays/collect.ts
@@ -395,6 +395,9 @@ export function collect(
                     const content = arg.text.slice(1, -1)
                     const realValue = evalAsciiBuiltin(content)
 
+                    if (realValue === undefined) {
+                        return true
+                    }
                     evaluateResultHint(result, call, realValue)
                 }
             }


### PR DESCRIPTION
Closes #573.
Closes #574.
