### PR TITLE
fix(formatter): trailing comments after the last struct field

### DIFF
--- a/server/src/compiler/fmt/formatter/format-structs.ts
+++ b/server/src/compiler/fmt/formatter/format-structs.ts
@@ -105,9 +105,9 @@ const formatFields: FormatRule = (code, node) => {
 
                 if (field.type === "Comment") {
                     if (needNewline) {
-                        code.add(" ")
+                        code.newLine()
                     }
-                    code.apply(formatComment, child)
+                    code.apply(formatComment, field)
                     code.newLine()
                     needNewline = false
                 } else if (field.type === "FieldDecl") {

--- a/server/src/compiler/fmt/test/top-level-comments.spec.ts
+++ b/server/src/compiler/fmt/test/top-level-comments.spec.ts
@@ -78,6 +78,20 @@ describe("top level declarations comments formatting", () => {
         struct Bar {}
     `));
 
+    it("comment after last field in struct", intact(`
+        struct RequestBody {
+            field: Address;
+            // Other data fields...
+        }
+    `));
+
+    it("comment after last field in message", intact(`
+        message RequestBody {
+            field: Address;
+            // Other data fields...
+        }
+    `));
+
     it("comments in message declarations", intact(`
         // before message
         message(0x123) Foo {


### PR DESCRIPTION
Closes #600

Backported one fix from the Tact compiler repo.