### PR TITLE
feat(vscode): show toolchain information on status bar widget hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,12 @@
                 "title": "Search by Type Signature",
                 "category": "Tact",
                 "icon": "$(symbol-method)"
+            },
+            {
+                "command": "tact.showToolchainInfo",
+                "title": "Show Toolchain Information",
+                "category": "Tact",
+                "icon": "$(info)"
             }
         ],
         "keybindings": [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -248,6 +248,8 @@ async function initialize(): Promise<void> {
 
         await connection.sendNotification(SetToolchainVersionNotification, {
             version: toolchain.version,
+            toolchain: toolchain.getToolchainInfo(),
+            environment: toolchain.getEnvironmentInfo(),
         } satisfies SetToolchainVersionParams)
     } catch (error) {
         if (error instanceof InvalidToolchainError) {

--- a/shared/src/shared-msgtypes.ts
+++ b/shared/src/shared-msgtypes.ts
@@ -17,11 +17,25 @@ export interface GetTypeAtPositionParams {
     }
 }
 
+export interface EnvironmentInfo {
+    readonly nodeVersion?: string
+    readonly platform: string
+    readonly arch: string
+}
+
+export interface ToolchainInfo {
+    readonly path: string
+    readonly isAutoDetected: boolean
+    readonly detectionMethod?: string
+}
+
 export interface SetToolchainVersionParams {
     readonly version: {
         readonly number: string
         readonly commit: string
     }
+    readonly toolchain: ToolchainInfo
+    readonly environment: EnvironmentInfo
 }
 
 export interface GetTypeAtPositionResponse {


### PR DESCRIPTION
Fixes #721
<img width="623" alt="Screenshot 2025-05-28 at 18 09 49" src="https://github.com/user-attachments/assets/67b28313-90a8-4753-bb8a-1371328303f1" />


<img width="623" alt="Screenshot 2025-05-28 at 18 09 12" src="https://github.com/user-attachments/assets/8f8bb9ce-923f-4a59-99b0-db7cd28a86a2" />

<img width="807" alt="Screenshot 2025-05-28 at 18 09 20" src="https://github.com/user-attachments/assets/b6c5e1f6-739a-4c16-9434-1306604f25cc" />

```
Tact Toolchain Information:
Version: 1.6.6
Commit: Unknown
Path: /Users/petrmakhnev/jetton/node_modules/.bin/tact
Auto-detected: true
Detection method: node_modules
Platform: darwin
Architecture: arm64
Node.js: v22.14.0
```
