### PR TITLE
feat: support contract `Contract.toCell/toSlice` from Tact 1.6.11 and `Contract.fromCell/fromSlice` from Tact 1.6.12

### DIFF
--- a/server/src/e2e/suite/testcases/completion/fromCell.test
+++ b/server/src/e2e/suite/testcases/completion/fromCell.test
@@ -43,3 +43,26 @@ fun test() {
 14 let  Create variable
 14 not  Negate expression
 14 repeat  Create repeat loop
+
+========================================================================
+fromCell/fromSlice for contract
+========================================================================
+primitive Int;
+
+fun AnyContract_fromCell(cell: Cell): M {}
+fun AnyContract_fromSlice(slice: Slice): M {}
+
+contract Foo {}
+
+fun test() {
+    Foo.<caret>;
+}
+------------------------------------------------------------------------
+2  fromCell(cell: Cell): M
+2  fromSlice(slice: Slice): M
+14 call  Use as function argument
+14 do  Create do-until loop
+14 if  Create if statement
+14 let  Create variable
+14 not  Negate expression
+14 repeat  Create repeat loop

--- a/server/src/e2e/suite/testcases/documentation/fromCell.test
+++ b/server/src/e2e/suite/testcases/documentation/fromCell.test
@@ -33,3 +33,21 @@ fun test() {
 ```tact
 fun fromSlice(slice: Slice): M {}
 ```
+
+========================================================================
+fromCell/fromSlice for contract
+========================================================================
+primitive Int;
+
+fun AnyContract_fromCell(cell: Cell): M {}
+fun AnyContract_fromSlice(slice: Slice): M {}
+
+contract Foo {}
+
+fun test() {
+    Foo.<caret>fromSlice();
+}
+------------------------------------------------------------------------
+```tact
+fun fromSlice(slice: Slice): M {}
+```

--- a/server/src/e2e/suite/testcases/resolve/fromCell.test
+++ b/server/src/e2e/suite/testcases/resolve/fromCell.test
@@ -29,3 +29,21 @@ fun test() {
 }
 ------------------------------------------------------------------------
 8:8 -> 3:4 resolved
+
+========================================================================
+fromCell/fromSlice for contract
+========================================================================
+primitive Int;
+
+fun AnyContract_fromCell(cell: Cell): M {}
+fun AnyContract_fromSlice(slice: Slice): M {}
+
+contract Foo {}
+
+fun test() {
+    Foo.<caret>fromSlice();
+    Foo.<caret>fromCell();
+}
+------------------------------------------------------------------------
+8:8 -> 3:4 resolved
+9:8 -> 2:4 resolved

--- a/server/src/e2e/suite/testcases/types/fromCell.test
+++ b/server/src/e2e/suite/testcases/types/fromCell.test
@@ -9,7 +9,7 @@ fun AnyStruct_fromSlice(slice: Slice): S {}
 struct Foo {}
 
 fun test() {
-    let f = Foo.<caret>;
+    let f = Foo.fromSlice();
     //  ^! Foo
 }
 ------------------------------------------------------------------------
@@ -26,7 +26,24 @@ fun AnyMessage_fromSlice(slice: Slice): M {}
 message Foo {}
 
 fun test() {
-    let f = Foo.<caret>;
+    let f = Foo.fromCell();
+    //  ^! Foo
+}
+------------------------------------------------------------------------
+ok
+
+========================================================================
+fromCell/fromSlice for contracts
+========================================================================
+primitive Int;
+
+fun AnyContract_fromCell(cell: Cell): M {}
+fun AnyContract_fromSlice(slice: Slice): M {}
+
+contract Foo {}
+
+fun test() {
+    let f = Foo.fromCell();
     //  ^! Foo
 }
 ------------------------------------------------------------------------

--- a/server/src/languages/tact/TypeInferer.ts
+++ b/server/src/languages/tact/TypeInferer.ts
@@ -261,7 +261,9 @@ export class TypeInferer {
             // Handle `Struct.fromCell()` calls
             if (
                 qualifier &&
-                (calledName.startsWith("AnyStruct_") || calledName.startsWith("AnyMessage_"))
+                (calledName.startsWith("AnyStruct_") ||
+                    calledName.startsWith("AnyMessage_") ||
+                    calledName.startsWith("AnyContract_"))
             ) {
                 return new Expression(qualifier, node.file).type()
             }

--- a/server/src/languages/tact/completion/ReferenceCompletionProcessor.ts
+++ b/server/src/languages/tact/completion/ReferenceCompletionProcessor.ts
@@ -83,8 +83,16 @@ export class ReferenceCompletionProcessor implements ScopeProcessor {
         if (!(node instanceof NamedNode)) return true
 
         const prefix = state.get("prefix") ?? ""
-        const name = trimPrefix(trimPrefix(node.name(), "AnyMessage_"), "AnyStruct_")
-        if (name.endsWith("DummyIdentifier") || name === "AnyStruct" || name === "AnyMessage") {
+        const name = trimPrefix(
+            trimPrefix(trimPrefix(node.name(), "AnyMessage_"), "AnyContract_"),
+            "AnyStruct_",
+        )
+        if (
+            name.endsWith("DummyIdentifier") ||
+            name === "AnyStruct" ||
+            name === "AnyMessage" ||
+            name === "AnyContract"
+        ) {
             return true
         }
 

--- a/server/src/languages/tact/documentation/documentation.ts
+++ b/server/src/languages/tact/documentation/documentation.ts
@@ -82,7 +82,10 @@ export async function generateDocFor(node: NamedNode, place: SyntaxNode): Promis
             const extraDoc =
                 func.name() === "require" ? requireFunctionDoc(place, node.file, settings) : ""
 
-            const name = trimPrefix(trimPrefix(node.name(), "AnyMessage_"), "AnyStruct_")
+            const name = trimPrefix(
+                trimPrefix(trimPrefix(node.name(), "AnyContract_"), "AnyMessage_"),
+                "AnyStruct_",
+            )
 
             return defaultResult(
                 `${func.modifiers()}fun ${name}${func.signaturePresentation()}${func.bodyPresentation(maxLinesBody)}`,

--- a/server/src/languages/tact/inlays/index.ts
+++ b/server/src/languages/tact/inlays/index.ts
@@ -17,6 +17,7 @@ import {
 import {
     BaseTy,
     BouncedTy,
+    ContractTy,
     MapTy,
     MessageTy,
     OptionTy,
@@ -128,6 +129,8 @@ function processToCellCall(call: CallLike, result: InlayHint[], showToCellSize: 
     if (!ty) {
         return
     }
+
+    if (ty instanceof ContractTy) return
 
     const sizeof = ty.sizeOf(new Map())
     if (!sizeof.valid) {


### PR DESCRIPTION

Fixes #736