### PR TITLE
docs(e2e): update test command examples in readme

### DIFF
--- a/server/src/e2e/README.md
+++ b/server/src/e2e/README.md
@@ -46,10 +46,10 @@ When working on a specific feature:
 
 ```bash
 # Work on completion for structs
-yarn test:e2e:completion:structs
+yarn test:e2e --suite completion --file structs.test
 
 # Work on type inference basics
-yarn test:e2e:types:basic
+yarn test:e2e --suite types --file basic.test
 
 # Test all completion features
 yarn test:e2e:completion


### PR DESCRIPTION
Remove outdated commands referencing missing scripts and show how to run specific suites/files using `yarn test:e2e`