### PR TITLE
fix: correct working directory path in BaseTestSuite

### DIFF
--- a/server/src/e2e/suite/BaseTestSuite.ts
+++ b/server/src/e2e/suite/BaseTestSuite.ts
@@ -33,7 +33,7 @@ export abstract class BaseTestSuite {
     }
 
     public workingDir(): string {
-        return path.join(__dirname, "../../../test-workspace/")
+        return path.join(__dirname, "../../../../../test-workspace/")
     }
 
     public async setup(): Promise<void> {


### PR DESCRIPTION
Update the relative path to point to the correct test-workspace location